### PR TITLE
Hardcode to keep only 1 log

### DIFF
--- a/nodeup/pkg/model/logrotate.go
+++ b/nodeup/pkg/model/logrotate.go
@@ -123,7 +123,7 @@ func (b *LogrotateBuilder) addLogRotate(c *fi.ModelBuilderContext, name, path st
 
 	lines := []string{
 		path + "{",
-		"  rotate 5",
+		"  rotate 1",
 		"  copytruncate",
 		"  missingok",
 		"  notifempty",


### PR DESCRIPTION
All of the logs that `kops` configures to rotate are sent to syslog so keeping only 1 log is sufficient.